### PR TITLE
Fix dtype mismatch 

### DIFF
--- a/scripts/tilevae.py
+++ b/scripts/tilevae.py
@@ -508,6 +508,7 @@ class VAEHook:
         @return: image
         """
         device = next(self.net.parameters()).device
+        dtype = next(self.net.parameters()).dtype
         net = self.net
         tile_size = self.tile_size
         is_decoder = self.is_decoder
@@ -647,7 +648,7 @@ class VAEHook:
 
         # Done!
         pbar.close()
-        return result if result is not None else result_approx.to(device)
+        return result.to(dtype) if result is not None else result_approx.to(device, dtype=dtype)
 
 
 class Script(scripts.Script):


### PR DESCRIPTION
When medvram or lowvram is enabled. Tiled VAE will cause dtype mismatch since it only hook the main part of VAE but ignore the final projection layers.

I add a mechanism to convert the output dtype to match weight dtype to avoid below error:
```
RuntimeError: Input type (float) and bias type (struct c10::Half) should be the same
```