### PR TITLE
use inputaccordions

### DIFF
--- a/scripts/tilediffusion.py
+++ b/scripts/tilediffusion.py
@@ -72,6 +72,10 @@ from tile_methods.abstractdiffusion import AbstractDiffusion
 from tile_methods.multidiffusion import MultiDiffusion
 from tile_methods.mixtureofdiffusers import MixtureOfDiffusers
 from tile_utils.utils import *
+if hasattr(opts, 'hypertile_enable_unet'):  # webui >= 1.7
+    from modules.ui_components import InputAccordion
+else:
+    InputAccordion = None
 
 CFG_PATH = os.path.join(scripts.basedir(), 'region_configs')
 BBOX_MAX_NUM = min(getattr(shared.cmd_opts, 'md_max_regions', 8), 16)
@@ -96,9 +100,14 @@ class Script(scripts.Script):
         is_t2i = 'true' if not is_img2img else 'false'
         uid = lambda name: f'MD-{tab}-{name}'
 
-        with gr.Accordion('Tiled Diffusion', open=False, elem_id=f'MD-{tab}'):
+        with (
+            InputAccordion(False, label='Tiled Diffusion', elem_id=uid('enabled')) if InputAccordion
+            else gr.Accordion('Tiled Diffusion', open=False, elem_id=f'MD-{tab}')
+            as enabled
+        ):
             with gr.Row(variant='compact') as tab_enable:
-                enabled = gr.Checkbox(label='Enable Tiled Diffusion', value=False,  elem_id=uid('enabled'))
+                if not InputAccordion:
+                    enabled = gr.Checkbox(label='Enable Tiled Diffusion', value=False,  elem_id=uid('enabled'))
                 overwrite_size = gr.Checkbox(label='Overwrite image size', value=False, visible=not is_img2img, elem_id=uid('overwrite-image-size'))
                 keep_input_size = gr.Checkbox(label='Keep input image size', value=True, visible=is_img2img, elem_id=uid('keep-input-size'))
 

--- a/scripts/tileglobal.py
+++ b/scripts/tileglobal.py
@@ -15,6 +15,10 @@ from tile_methods.demofusion import DemoFusion
 from tile_utils.utils import *
 from modules.sd_samplers_common import InterruptedException
 # import k_diffusion.sampling
+if hasattr(opts, 'hypertile_enable_unet'):  # webui >= 1.7
+    from modules.ui_components import InputAccordion
+else:
+    InputAccordion = None
 
 
 CFG_PATH = os.path.join(scripts.basedir(), 'region_configs')
@@ -54,9 +58,16 @@ class Script(scripts.Script):
         is_t2i = 'true' if not is_img2img else 'false'
         uid = lambda name: f'MD-{tab}-{name}'
 
-        with gr.Accordion('DemoFusion', open=False, elem_id=f'MD-{tab}'):
+        with (
+            InputAccordion(False, label='DemoFusion', elem_id=uid('enabled')) if InputAccordion
+            else gr.Accordion('DemoFusion', open=False, elem_id=f'MD-{tab}')
+            as enabled
+        ):
             with gr.Row(variant='compact') as tab_enable:
-                enabled = gr.Checkbox(label='Enable DemoFusion(Dont open with tilediffusion)', value=False,  elem_id=uid('enabled'))
+                if not InputAccordion:
+                    enabled = gr.Checkbox(label='Enable DemoFusion(Dont open with tilediffusion)', value=False,  elem_id=uid('enabled'))
+                else:
+                    gr.Markdown('(Dont open with tilediffusion)')
                 random_jitter = gr.Checkbox(label='Random Jitter', value = True, elem_id=uid('random-jitter'))
                 gaussian_filter = gr.Checkbox(label='Gaussian Filter', value=True, visible=False, elem_id=uid('gaussian'))
                 keep_input_size = gr.Checkbox(label='Keep input-image size', value=False,visible=is_img2img, elem_id=uid('keep-input-size'))


### PR DESCRIPTION
To allow enabling with no opening the accordions. I find it very important especially for this extension, because user sets all settings 1 time according to their vram, and opens it later almost only to enable it 

![Screenshot_20240328_192801](https://github.com/pkuliyi2015/multidiffusion-upscaler-for-automatic1111/assets/33491867/3bb9de20-7ae2-4e5c-b64a-b7262b37d7fe)

For sd-webui 1.6 it works the same as before

![Screenshot_20240328_192632](https://github.com/pkuliyi2015/multidiffusion-upscaler-for-automatic1111/assets/33491867/35a16a48-bd13-437b-8951-4e6df3775d91)

btw: is it correct for tiled vae? `uid = lambda name: f'MD-{tab}-{name}'` Maybe should be MDV