### PR TITLE
Fix dtype error in precision=half in macos

### DIFF
--- a/scripts/tilevae.py
+++ b/scripts/tilevae.py
@@ -234,7 +234,7 @@ def custom_group_norm(input, num_groups, mean, var, weight=None, bias=None, eps=
     input_reshaped = input.contiguous().view(
         1, int(b * num_groups), channel_in_group, *input.size()[2:])
 
-    out = F.batch_norm(input_reshaped, mean, var, weight=None, bias=None, training=False, momentum=0, eps=eps)
+    out = F.batch_norm(input_reshaped, mean.to(input), var.to(input), weight=None, bias=None, training=False, momentum=0, eps=eps)
     out = out.view(b, c, *input.size()[2:])
 
     # post affine transform


### PR DESCRIPTION
As title,
when mean/var in f32 and input in f16, mps backend will directly crash.
<img width="1788" alt="image" src="https://github.com/user-attachments/assets/9d7d8ca8-1c6e-43ef-a351-e3dec3cdb054">


This PR fix this problem.